### PR TITLE
Disable VRCFT in desktop mod (with config to enable it back)

### DIFF
--- a/VRCFT2CVR/Config.cs
+++ b/VRCFT2CVR/Config.cs
@@ -8,10 +8,13 @@ internal static class Config
 
     public static bool IntegratedTrackingSupport => integratedTrackingSupport.Value;
     public static bool UseBinaryParameters => useBinaryParameters.Value;
+
+    public static bool EnabledInDesktop => enabledInDesktop.Value;
     
     internal static MelonPreferences_Category preferencesCategory = MelonPreferences.CreateCategory(MainMod.MOD_NAME + " Settings");
     internal static MelonPreferences_Entry<bool> integratedTrackingSupport;
     internal static MelonPreferences_Entry<bool> useBinaryParameters;
+    internal static MelonPreferences_Entry<bool> enabledInDesktop;
     private static MelonPreferences_Entry<int> configVersion;
     internal static MelonPreferences_Entry<Dictionary<string, string>> facialTrackingSettings;
     
@@ -21,6 +24,8 @@ internal static class Config
             "Integrated Tracking Support", "(Experimental) Implements support for CVR's built-in Face Tracking");
         useBinaryParameters = preferencesCategory.CreateEntry("useBinaryParameters", true, "Use Binary Parameters",
             "Registers VRCFT's Binary Parameters");
+        enabledInDesktop = preferencesCategory.CreateEntry("enabledInDesktop", true, "Enabled in Desktop",
+            "Loads VRCFT in desktop mode");
         facialTrackingSettings = preferencesCategory.CreateEntry("facialTrackingSettings",
             new Dictionary<string, string>(), "Facial Tracking Settings", "All of the VRCFT Facial Tracking Settings");
         configVersion = preferencesCategory.CreateEntry("ConfigVersion", CONFIG_VERSION, description: "DO NOT CHANGE!");

--- a/VRCFT2CVR/MainMod.cs
+++ b/VRCFT2CVR/MainMod.cs
@@ -54,7 +54,12 @@ public class MainMod : MelonMod
 
     public override void OnLateUpdate()
     {
-        if(loaded) return;
+        if (loaded) return;
+        if (!Config.EnabledInDesktop && !MetaPort.Instance.isUsingVr)
+        {
+            optionalUI ??= new OptionalUI();
+            return;
+        }
         Player? localPlayer = GetLocalPlayer();
         if(FaceTrackingManager.Instance == null || EyeTrackingManager.Instance == null || localPlayer == null) return;
         if (Runner.Instance == null)
@@ -142,7 +147,7 @@ public class MainMod : MelonMod
             if(!Config.IntegratedTrackingSupport) NoIntegratedLoad();
             MelonLogger.Msg("Loaded VRCFT2CVR!");
             loaded = true;
-            optionalUI = new OptionalUI();
+            optionalUI ??= new OptionalUI();
         }
     }
 

--- a/VRCFT2CVR/MainMod.cs
+++ b/VRCFT2CVR/MainMod.cs
@@ -5,6 +5,7 @@ using ABI_RC.Core.Player;
 using ABI_RC.Core.Player.EyeMovement;
 using ABI_RC.Core.Savior;
 using ABI_RC.Systems.FaceTracking;
+using ABI_RC.Systems.VRModeSwitch;
 using HarmonyLib;
 using MelonLoader;
 using Tobii.Gaming;
@@ -37,6 +38,16 @@ public class MainMod : MelonMod
     
     private bool loaded;
     private bool didIntegrate;
+
+    MainMod() => VRModeSwitchEvents.OnPostVRModeSwitch.AddListener(switchedToXr =>
+    {
+        if (Config.EnabledInDesktop || switchedToXr) return;
+
+        // If we're not in VR anymore, and we don't want the module to be on, we'll clear things out
+        HarmonyInstance.UnpatchSelf();
+        Hypernex.ExtendedTracking.FaceTrackingManager.Destroy();
+        loaded = false;
+    }); 
 
     public override void OnUpdate()
     {

--- a/VRCFT2CVR/OptionalUI.cs
+++ b/VRCFT2CVR/OptionalUI.cs
@@ -54,6 +54,12 @@ internal class OptionalUI
             pageType.GetMethod("AddCategory", new Type[1] {typeof(string)})!.Invoke(rootPage,
                 new object[1] {MainMod.MOD_NAME + " Settings"});
         // Toggles
+        CreateToggle(Config.enabledInDesktop, categoryType, toggleType,
+            new object[3]
+            {
+                Config.enabledInDesktop.DisplayName, Config.enabledInDesktop.Description,
+                Config.enabledInDesktop.Value
+            });
         CreateToggle(Config.integratedTrackingSupport, categoryType, toggleType,
             new object[3]
             {


### PR DESCRIPTION
I mean, I was already working on it yesterday and it's really annoying to have it load in desktop mode cause the SteamLinkVRCFTModule logs like crazy and throws error all the time in the console. So I made a setting and disabled it in desktop by default (using a silly env variable check, which means VR Switching doesn't work)